### PR TITLE
bootstrapのリンクをbase.cssから削除。

### DIFF
--- a/ChatApp/static/css/bookroom.css
+++ b/ChatApp/static/css/bookroom.css
@@ -163,10 +163,6 @@
   object-fit: contain; /* アスペクト比を維持して表示 */
 }
 
-.pagination {
-  color: black;
-}
-
 /* ================== フローティングアクションボタン (FAB) ================== */
 .create-bookroom-button { /* 新しいセレクタとして追加 */
   position: fixed;

--- a/ChatApp/templates/bookroom.html
+++ b/ChatApp/templates/bookroom.html
@@ -48,7 +48,6 @@
       {{ pagination.info }}
       {{ pagination.links }}
     </div>
-
   </div>
 
   {# Floating Action Button #}


### PR DESCRIPTION
### 概要
このPull Requestの目的を簡潔に説明してください。
bootstrapのリンクを追加した影響で、他のレイアウトが崩れてしまった。
そのため、bootstrapのリンクを削除した。

### 変更内容
- bootstrapのリンクをbase.cssから削除。
- bookroom.htmlのページネーション部分のクラス名を変更した

### 関連Issue
- Issue番号（例: #123）

### 関連する問題（必要に応じて）
https://github.com/2025Autumn-Hackathon-L-team/dokkai/issues/77

### スクリーンショット（必要に応じて）
