### PR TITLE
B8-3.2make profile view プロフィールの表示の変更とサインアップの修正

### DIFF
--- a/ChatApp/app.py
+++ b/ChatApp/app.py
@@ -317,14 +317,16 @@ def profile_view():
         return redirect(url_for('login_view'))
     current_name=session.get("user_name")
     current_email=session.get("user_email")
+    icon_view=Profile.icon_view(current_uid)
     messages_count=Profile.get_messages_count(current_uid) 
     # TODO リアクション機能実装後、リアクションの数を取得する。
     #printはサーバーで出る値を確認。後日削除する。
+    print(f'{icon_view}はiconidです')
     print(f'{current_uid}はprofile.htmlで現在セッションを持っているユーザーです')
     print(f'{current_name}はprofile.htmlで現在セッションを持っているユーザーのnameを表示しています')
     print(f'{current_email}はprofile.htmlで現在セッションを持っているユーザーのemailを表示しています')
     print(f'{messages_count}は{current_name}が投稿したメッセージの数を表しています')
-    return render_template("profile.html",uid=current_uid,name=current_name,email=current_email,messages_count=messages_count)
+    return render_template("profile.html",icon=icon_view,uid=current_uid,name=current_name,email=current_email,messages_count=messages_count)
 
 ########プロフィール画面（ここまで）##########
 

--- a/ChatApp/models.py
+++ b/ChatApp/models.py
@@ -220,6 +220,22 @@ class Message:
 
 ############################プロフィール画面関係（ここから)############################
 class Profile:
+    # アイコンの表示
+    @classmethod
+    def icon_view(cls,iconid):
+        conn = db_pool.get_conn()
+        try:
+            with conn.cursor() as cur:
+                sql = "SELECT iconid FROM users WHERE id=%s"
+                cur.execute(sql,(iconid,))
+                user_icon=cur.fetchone()
+                return user_icon['iconid']
+        except pymysql.Error as e:
+            print(f'エラーが発生しています：{e}')
+            abort(500)
+        finally:
+            db_pool.release(conn)
+
     # アイコンの変更
     @classmethod
     def icon_update(cls,iconid):

--- a/ChatApp/templates/profile.html
+++ b/ChatApp/templates/profile.html
@@ -2,6 +2,7 @@
 <title>profile</title>
 {% block body %}
 <div class="profile_main_container">
+    <p>ユーザアイコンは{{icon}}</p>
     <p>{{uid}}がログインしています</p>
     <p>nameは{{name}}</p>
     <p>emailは{{email}}</p>


### PR DESCRIPTION
### 概要
このPull Requestの目的を簡潔に説明してください。
プロフィールの表示の変更とサインアップの修正

### 変更内容
- 変更点1　サインアップした後のリダイレクト先が誤っていたので修正しました。
- 変更点2　サインアップ後にプロフィール画面に遷移した際に持つセッション情報を修正しました。
- 変更点3　T_usersに格納しているiconidの値が表示できるようにしました。

### 関連Issue
- Issue番号
- B8-3

### 関連する問題（必要に応じて）
ログイン後とサインアップ後のセッションの持ち方は、もっと簡潔に記載できないか検討したい。
