### PR TITLE
private bookroomで異なるユーザの場合は同じブックルーム名をつけられるようにした

### DIFF
--- a/ChatApp/app.py
+++ b/ChatApp/app.py
@@ -281,9 +281,7 @@ def create_public_bookroom():
         flash("ブックルーム名を入力してください")
         return redirect(url_for("create_public_bookroom"))
 
-    bookroom = Bookroom.find_by_bookroom_name(
-        bookroom_name=bookroom_name, is_public=True
-    )
+    bookroom = Bookroom.find_by_public_bookroom_name(bookroom_name=bookroom_name)
     if bookroom is None:
         bookroom_description = request.form.get("bookroom_description")
         bookroom_id = Bookroom.create(
@@ -457,8 +455,8 @@ def create_private_bookroom():
         flash("ブックルーム名を入力してください")
         return redirect(url_for("create_private_bookroom"))
 
-    bookroom = Bookroom.find_by_bookroom_name(
-        bookroom_name=bookroom_name, is_public=False
+    bookroom = Bookroom.find_by_private_bookroom_name(
+        bookroom_name=bookroom_name, user_id=user_id
     )
     if bookroom is None:
         bookroom_description = request.form.get("bookroom_description")

--- a/ChatApp/models.py
+++ b/ChatApp/models.py
@@ -63,11 +63,11 @@ class User:
 # ブックルームクラス
 class Bookroom:
     @classmethod
-    def find_by_bookroom_name(cls, bookroom_name, is_public=None):
+    def find_by_public_bookroom_name(cls, bookroom_name):
         conn = db_pool.get_conn()
         try:
             with conn.cursor() as cur:
-                sql = "SELECT * FROM bookrooms WHERE name=%s AND is_public=%s"
+                sql = "SELECT * FROM bookrooms WHERE name=%s AND is_public=TRUE"
                 cur.execute(sql, (bookroom_name, is_public))
                 bookroom = cur.fetchone()
                 return bookroom
@@ -76,6 +76,23 @@ class Bookroom:
             abort(500)
         finally:
             db_pool.release(conn)
+
+    # private bookroomかつ同じユーザで同じチャンネル名がないかを確認
+    @classmethod    
+    def find_by_private_bookroom_name(cls, bookroom_name, user_id):
+        conn = db_pool.get_conn()
+        try:
+            with conn.cursor() as cur:
+                sql = "SELECT * FROM bookrooms WHERE name=%s AND is_public=FALSE AND user_id=%s"
+                cur.execute(sql, (bookroom_name, user_id))
+                bookroom = cur.fetchone()
+                return bookroom
+        except pymysql.Error as e:
+            print(f"エラーが発生しています：{e}")
+            abort(500)
+        finally:
+            db_pool.release(conn)
+
 
     @classmethod
     def find_by_bookroom_id(cls, bookroom_id):

--- a/Docker/MySQL/init.sql
+++ b/Docker/MySQL/init.sql
@@ -30,7 +30,7 @@ CREATE TABLE bookrooms (
     is_public BOOLEAN NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    UNIQUE KEY (name, is_public),
+    UNIQUE KEY (name, is_public, user_id),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
### 概要
private bookroomでユーザが異なっていても、同じブックルーム名をつけられなくなっていた。
そのため、ユーザーが異なる場合は同じブックルーム名をつけられるように変更した。

### 変更内容
- 変更点1
- 変更点2
- 変更点3

### 関連Issue
- Issue番号（例: #123）
B2-1

### 関連する問題（必要に応じて）

### スクリーンショット（必要に応じて）
https://www.loom.com/share/0d477c44e90e4e1db64c140987469913
<img width="1261" height="266" alt="image" src="https://github.com/user-attachments/assets/644e8e72-8ca9-4e6c-940e-ab26b7d82d6d" />
