### PR TITLE
現在時刻表示機能実装

### DIFF
--- a/ChatApp/models.py
+++ b/ChatApp/models.py
@@ -336,6 +336,7 @@ class Message:
                     u.id AS user_id,
                     u.name AS user_name,
                     m.content AS message,
+                    m.created_at,
                     COALESCE(i.icon_image, '/static/img/icons/icon_rabbit.png') AS icon_image
                     FROM messages AS m 
                     INNER JOIN users AS u ON m.user_id = u.id 

--- a/ChatApp/templates/private_messages.html
+++ b/ChatApp/templates/private_messages.html
@@ -37,7 +37,7 @@
         <img src="{{ url_for('static', filename='img/trash-can.png') }}" alt="アイコン" >
          </button>
       </form>  
-      <span class="timestamp timestamp-right">2025/10/28 16:54</span>
+      <span class="timestamp timestamp-right">{{ message.created_at.strftime("%Y/%m/%d %H:%M") }}</span>
       </div>
             <div class="reaction-zone reaction-zone-left">
             </div>   
@@ -48,9 +48,9 @@
         <p class="user-name">{{message.user_name | default("メッセージテーブルのユーザーネーム")}}</p>
          <div class="icon-and-message-left">
           <img class="user-icon" src="{{message.icon_image}}" alt="ユーザーアイコン">
-          <p class="box box-left">{{message.message| default("メッセージテーブルの内容")}}</p>
+          <p class="box box-left">{{message.message}}</p>
          </div> 
-          <span class="timestamp timestamp-left">2025/10/28 16:54</span>
+          <span class="timestamp timestamp-left">{{ message.created_at.strftime("%Y/%m/%d %H:%M") }}</span>
             <div class="reaction-zone reaction-zone-left">
               <button class="reaction-item">
                 👍 <span class="reaction-count">5</span></button>

--- a/ChatApp/templates/public_messages.html
+++ b/ChatApp/templates/public_messages.html
@@ -37,7 +37,7 @@
         <img src="{{ url_for('static', filename='img/trash-can.png') }}" alt="アイコン" >
          </button>
       </form>  
-      <span class="timestamp timestamp-right">2025/10/28 16:54</span>
+      <span class="timestamp timestamp-right">{{ message.created_at.strftime("%Y/%m/%d %H:%M") }}</span>
       </div>
             <div class="reaction-zone reaction-zone-left">
               <button class="reaction-item">
@@ -56,7 +56,7 @@
           <img class="user-icon" src="{{message.icon_image}}" alt="ユーザーアイコン">
           <p class="box box-left">{{message.message| default("メッセージテーブルの内容")}}</p>
         </div> 
-          <span class="timestamp timestamp-left">2025/10/28 16:54</span>
+          <span class="timestamp timestamp-left">{{ message.created_at.strftime("%Y/%m/%d %H:%M") }}</span>
             <div class="reaction-zone reaction-zone-left">
               <button class="reaction-item">
                 👍 <span class="reaction-count">5</span></button>

--- a/Docker/MySQL/my.cnf
+++ b/Docker/MySQL/my.cnf
@@ -2,7 +2,7 @@
 character_set_server=utf8mb4
 collation_server=utf8mb4_bin
 
-default_time_zone=SYSTEM
+default_time_zone='+09:00'
 log_timestamps=SYSTEM
 
 default_authentication_plugin=mysql_native_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
       - ./Docker/MySQL/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./Docker/MySQL/my.cnf:/etc/mysql/conf.d/my.cnf
     # コンテナ内の環境変数を設定
     environment:
       - MYSQL_ROOT_PASSWORD=${DB_ROOT_PASSWORD}


### PR DESCRIPTION
public / private のメッセージ一覧画面に、メッセージ作成日時（created_at）を表示する機能を実装いたしました。

<変更点>
・MySQL のタイムゾーン設定（JST）を追加
・Message.get_all() で created_at を取得
・Jinja2 テンプレートで時刻を「YYYY/MM/DD HH:MM」形式に整形
・public / private 両方のテンプレートに反映
### 関連Issue
B3

### 関連する問題（必要に応じて）

### スクリーンショット（必要に応じて）
