### PR TITLE
ブックルーム画面でdescriptionがない場合にタグが枠から縦にはみ出すエラーを修正

### DIFF
--- a/ChatApp/static/css/bookroom.css
+++ b/ChatApp/static/css/bookroom.css
@@ -158,7 +158,7 @@ background-color: transparent;
   align-items: center;
   transition: transform 0.2s ease-in-out;
   position: relative;
-  min-width: 70px;
+  min-height: 70px;
 }
 /* プライベートブックルームのbookroom in bookrooms の各要素に適用 */
 .room-item-card_private { 
@@ -173,7 +173,7 @@ background-color: transparent;
   align-items: center;
   transition: transform 0.2s ease-in-out;
   position: relative;
-  min-width: 70px;
+  min-height: 70px;
 
 }
 /* 軽く浮き上がるエフェクト */


### PR DESCRIPTION
### 概要
room-item-cardにmin-height を設定

### 変更内容
- 変更点1
- 各ブックルームのroom-item-cardの高さ調整

### 関連Issue
- Issue番号（例: #123）
F2
### 関連する問題（必要に応じて）

### スクリーンショット（必要に応じて）
