### PR TITLE
プロフィール画面のname変更モーダルが挙動しないエラーを修正

### DIFF
--- a/ChatApp/templates/modal/update-icon.html
+++ b/ChatApp/templates/modal/update-icon.html
@@ -14,10 +14,11 @@
             <img class="icon-image" src="{{ icon.icon_image }}" alt="{{ icon.icon_name }}">
           </button>
         {% endfor %}
-      <div></div>
+        </form>
+      
       <div class="pagination-container" id="pagination_icon">
       {{ pagination.links }}
-      <div></div>
+      
       </div>
     </div>
   </div>

--- a/ChatApp/templates/profile.html
+++ b/ChatApp/templates/profile.html
@@ -20,7 +20,6 @@
             <button class="update-profile-button" id="update-icon-button" label="iconの変更">
                 <img class="button-image" src="{{ url_for('static', filename='img/pen.png') }}">
             </button>
-            {% include 'modal/update-icon.html' %} 
         </div>
       <!-- バリデーションチェック成功時のメッセージ表示-->
     {% with messages = get_flashed_messages(category_filter=["success_flash"]) %}
@@ -60,7 +59,6 @@
               <button class="update-profile-button" id="update-name-button" label="nameの変更">
                 <img class="button-image" src="{{ url_for('static', filename='img/pen.png') }}">
               </button>
-              {% include 'modal/update-profile-name.html' %} 
           </div>
           <div id="name-side-adjustment">
             <p>{{name}}</p>
@@ -74,7 +72,6 @@
               <button class="update-profile-button" id="update-email-button" label="emailの変更">
                 <img class="button-image" src="{{ url_for('static', filename='img/pen.png') }}">
               </button>
-              {% include 'modal/update-profile-email.html' %} 
           </div>
           <div id="email-side-adjustment">
             <p>{{email}}</p>
@@ -83,7 +80,9 @@
     </div>
 </div>
 </body>
-
+{% include 'modal/update-icon.html' %} 
+{% include 'modal/update-profile-name.html' %} 
+{% include 'modal/update-profile-email.html' %}
 {% endblock %}
 {% block script %}
 <script


### PR DESCRIPTION
### 概要
プロフィール画面の以下のエラーを修正
1.profileページのnameのモーダルが開かない
2.アイコン選択モーダルでアイコンを変更し、name変更モーダルボタンをクリックするとアイコンが初期値に戻る

### 変更内容
- update-icon.htmlで/form閉じタグが消えていたので追加
- profile.htmlで空のdivタグがあったため削除

### 関連Issue
- Issue番号（例: #123）

### 関連する問題（必要に応じて）

### スクリーンショット（必要に応じて）
