### PR TITLE
アイコンモーダルのページネーションを実装

### DIFF
--- a/ChatApp/app.py
+++ b/ChatApp/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, redirect, url_for, session, request, flash
+from flask import Flask, render_template, redirect, url_for, session, request, flash, jsonify
 from flask_paginate import Pagination, get_page_parameter
 from datetime import timedelta
 from zoneinfo import ZoneInfo
@@ -910,20 +910,6 @@ def profile_view():
     current_email = Profile.email_view(user_id)
     icon_view = Profile.icon_view(user_id)
     messages_count = Profile.get_messages_count(user_id)
-    icons = Icon.get_all()
-
-# ページネーション
-    page = request.args.get(get_page_parameter(), type=int, default=1)
-    paginated_icons = icons[(page - 1) * 12 : page * 12]
-    pagination = Pagination(
-        page=page,
-        total=len(icons),
-        per_page=12,
-        css_framework="bootstrap5",
-        display_pages=True,
-        record_name="アイコン",
-    )
-
 
     # TODO リアクション機能実装後、リアクションの数を取得する。
     return render_template(
@@ -933,9 +919,34 @@ def profile_view():
         name=current_name,
         email=current_email,
         messages_count=messages_count,
-        icons=paginated_icons,
-        pagination=pagination,  
     )
+
+# アイコンの編集モーダルで、JSでページネーションするのに、json形式でデータを返す必要がある
+@app.route("/profile/icons")
+def profile_icons_js():
+    user_id = session.get("user_id")
+
+    if user_id is None:
+        return redirect(url_for("login_view"))
+
+    page = request.args.get("page", type=int, default=1)
+    icons = Icon.get_all()
+    print(f'{page}はpage')
+    print(f'{icons}はicons')
+
+    per_page = 12
+    total = len(icons)
+    print(f'{total}はtotal')
+    paginated_icons = icons[(page - 1) * per_page : page * per_page]
+    print(f'{paginated_icons}はpaginated_icons')
+    total_pages = (total + per_page - 1) // per_page
+    print(f'{total_pages}はtotal_pages')
+
+    return jsonify({
+        "page": page,
+        "total_pages": total_pages,
+        "icons": paginated_icons
+    })
 
 
 # プロフィール画面の編集(name)

--- a/ChatApp/models.py
+++ b/ChatApp/models.py
@@ -528,7 +528,6 @@ class Message:
 ############################プロフィール画面関係（ここから)############################
 class Profile:
     # アイコンの表示
-    # TODO M_iconsテーブルができたら、iconidでなく画像のパスを返す形に変える
     @classmethod
     def icon_view(cls, user_id):
         conn = db_pool.get_conn()

--- a/ChatApp/static/css/modal.css
+++ b/ChatApp/static/css/modal.css
@@ -304,7 +304,7 @@
   padding: 10px 0;
 }
 
-.modal-icons-body {
+#icon-area {
     padding: 0 10px;
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
@@ -347,6 +347,16 @@
 #pagination_icon ul{
   padding: 0;
   margin: 0;
+}
+
+.page-btn{
+  color: black;
+  background-color: #FFFACD;
+  padding: 8px;
+}
+
+.page-btn.active {
+  color: royalblue;
 }
 
 /*アイコン更新モーダルここまで*/

--- a/ChatApp/static/css/profile.css
+++ b/ChatApp/static/css/profile.css
@@ -73,6 +73,7 @@ body.profile-body {
   align-items: center;
   justify-content: space-between;
   width: 300px;
+  height: 45px;
 }
 
 .button-position-adjustment img{

--- a/ChatApp/static/js/Profile/update-icon.js
+++ b/ChatApp/static/js/Profile/update-icon.js
@@ -5,6 +5,8 @@
 const updateIconButton = document.getElementById("update-icon-button");
 const updateIconModal = document.getElementById("update-icon-modal");
 const updateIconButtonClose = document.getElementById("update-icon-close-button");
+const iconArea = document.getElementById("icon-area");
+const paginationContainer = document.getElementById("pagination_icon");
 
 // モーダルが存在するページのみ（uidとチャンネルidが同じ時のみ）
 if (updateIconModal) {
@@ -25,3 +27,44 @@ if (updateIconModal) {
     }
   });
 }
+
+// app.pyのprofile_icons_js関数を実行して、json形式のデータをもらう
+async function loadIcons(page = 1) {
+  const iconresponse = await fetch(`/profile/icons?page=${page}`, { cache: "no-store" });
+  const data = await iconresponse.json();
+  
+  // モーダル内に表示を取得した要素に置き換える
+  renderIcons(data.icons);
+  renderPagination(data.page, data.total_pages);
+}
+
+// アイコン一覧を取得し、innerHTMLに入れて新しいHTMLの配列を作成しHTML上に返す（モーダル内の表示を差し替える）
+function renderIcons(icons) {
+  iconArea.innerHTML = icons.map(icon => `
+    <button class="icon_styled" type="submit" name="icon_name" value="${icon.id}">
+      <img class="icon-image" src="${icon.icon_image}" alt="${icon.icon_name}">
+    </button>
+  `).join("");
+}
+
+// モーダル内にページ番号を表示
+function renderPagination(current, total) {
+  paginationContainer.innerHTML = ""; // ページ番号を描画するところを一旦リセットする。
+  if (total <= 1) return; // 総ページが１ページ以下ならページネーション不要。そのまま返す。
+
+  // ページネーションのボタン
+  for (let pagenumber = 1; pagenumber <= total; pagenumber++) {
+    const btn = document.createElement("button"); // ボタンを作成
+    btn.className = "page-btn";
+    btn.textContent = pagenumber;
+    if (pagenumber === current) btn.classList.add("active"); // 現在のページをアクティブにする
+    btn.addEventListener("click", () => loadIcons(pagenumber)); // ボタンをクリックするとそのページのアイコンだけ読み込む
+    paginationContainer.appendChild(btn); // 作ったボタンをHTMLに追加
+  }
+}
+
+// モーダルが開いたら 1ページ目表示
+updateIconButton.addEventListener("click", () => {
+  updateIconModal.style.display = "flex";
+  loadIcons(1);
+});

--- a/ChatApp/templates/modal/update-icon.html
+++ b/ChatApp/templates/modal/update-icon.html
@@ -9,15 +9,14 @@
             <p>変更したいアイコンをクリックしてください</p>
         </div>
         <form class="modal-icons-body" name="updateIcon" action="/icons/update" method="POST">
-        {% for icon in icons %}
-          <button class="icon_styled" type="submit" name="icon_name" value="{{ icon.id }}">
-            <img class="icon-image" src="{{ icon.icon_image }}" alt="{{ icon.icon_name }}">
-          </button>
-        {% endfor %}
-      <div></div>
-      <div class="pagination-container" id="pagination_icon">
-      {{ pagination.links }}
-      <div></div>
+          <div id="icon-area"></div>
+            {% for icon in icons %}
+              <button class="icon_styled" type="submit" name="icon_name" value="{{ icon.id }}">
+                <img class="icon-image" src="{{ icon.icon_image }}" alt="{{ icon.icon_name }}">
+              </button>
+            {% endfor %}
+        </form>
+        <div class="pagination-container" id="pagination_icon"></div>
       </div>
     </div>
   </div>

--- a/ChatApp/templates/profile.html
+++ b/ChatApp/templates/profile.html
@@ -43,14 +43,10 @@
           <div class="reactions-messages-between-position-adjustment">
           </div>
           <div>
-            <p class="little_title">talk in bookroom</p>
+            <p class="little_title">Talk in bookroom</p>
             <p class="bigger_font">{{messages_count}}</p>
           </div>
         </div>
-        <!--your make bookroomsを表示して、そこからbookroomに行けるようにしたい
-        <div>
-          <p class="profile-subtitle">show bookrooms</p>
-        </div>-->
         <!--nameの表示-->
         <div class="name-position-adjustment">
           <!--値確認用<p>ユーザアイコンは{{icon}}</p>-->


### PR DESCRIPTION
### 概要
アイコンモーダルのページネーションをJSで実装した。

### 変更内容
- Flaskだとページボタンを押すと画面遷移してしまいモーダルが閉じてしまうので、アイコンモーダルだけページネーションを行った。

### 関連Issue
- Issue番号（例: #123）
B8

### 関連する問題（必要に応じて）
ディベロッパーツールだと、IphoneSEだけモーダルの×ボタンとハンバーガーメニューがかぶる。

