### PR TITLE
モバイルのサインアウトのボタンのURLを修正。

### DIFF
--- a/ChatApp/templates/util/mobile-header.html
+++ b/ChatApp/templates/util/mobile-header.html
@@ -46,7 +46,7 @@
             </a>
           </li>
           <li class="page-links">
-            <a href="logout">
+            <a href="{{ url_for('logout') }}">
               <span class="icon">
                   <img src="{{ url_for('static', filename='img/signout.png')}}" alt="signout_icon" width="24" height="24">
               </span>


### PR DESCRIPTION
### 概要
パブリックモバイルのサインアウトのボタンがログアウトに遷移しないので修正を行った。

### 変更内容
- モバイルのサインアウトのボタンがログアウトに遷移しないのでmobile-header.htmlの修正を行った。
- PC版は問題なくログアウトできました。

### 関連Issue
- Issue番号
- B1

